### PR TITLE
Add support for PayPal Advanced Checkout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,20 @@ AWS_SES_REGION = 'us-east-1'
 PAYPAL_TEST = TRUE
 PAYPAL_ACCOUNT = ''
 
+# PayPal Advanced Checkout (Orders v2 REST API)
+# Create a REST API app at https://developer.paypal.com/dashboard/ to get
+# the client id / secret. PAYPAL_TEST=TRUE above selects the sandbox
+# environment (api-m.sandbox.paypal.com); FALSE selects live.
+PAYPAL_CLIENT_ID = ''
+PAYPAL_CLIENT_SECRET = ''
+# Webhook ID for PAYMENT.CAPTURE.COMPLETED / DENIED events. Create the
+# webhook under the same REST API app once the endpoint URL is live.
+PAYPAL_WEBHOOK_ID = ''
+# Feature flag: set to TRUE to switch the donation flow to Advanced
+# Checkout (inline card fields). Leave FALSE to keep the legacy
+# Payments Standard + IPN flow.
+PAYPAL_ADVANCED_CHECKOUT = FALSE
+
 # Enter a comma-separated list of domains that are allowed to access the site
 ALLOWED_HOSTS="localhost,something.domain"
 CSRF_TRUSTED_ORIGINS="https://localhost,https://something.domain"

--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ backup/
 
 # Docker override file (local configuration)
 docker-compose.override.yml
+
+# Node modules
+node_modules/

--- a/fundraiser/settings/base.py
+++ b/fundraiser/settings/base.py
@@ -174,3 +174,20 @@ CRISPY_TEMPLATE_PACK = 'bootstrap4'
 # Must be set in environment variables or overridden in settings files
 RECAPTCHA_PUBLIC_KEY = os.getenv('RECAPTCHA_PUBLIC_KEY', '')
 RECAPTCHA_PRIVATE_KEY = os.getenv('RECAPTCHA_PRIVATE_KEY', '')
+
+# PayPal Advanced Checkout (Orders v2 REST API) settings
+# PAYPAL_TEST (read in dev.py / prod.py) selects sandbox vs live base URL.
+# Credentials are optional here so dev/test envs without PayPal configured
+# still boot; paypal_api.py raises if they are missing at call time.
+PAYPAL_CLIENT_ID = os.getenv('PAYPAL_CLIENT_ID', '')
+PAYPAL_CLIENT_SECRET = os.getenv('PAYPAL_CLIENT_SECRET', '')
+PAYPAL_WEBHOOK_ID = os.getenv('PAYPAL_WEBHOOK_ID', '')
+PAYPAL_API_BASE = (
+    'https://api-m.sandbox.paypal.com'
+    if read_boolean(os.getenv('PAYPAL_TEST'))
+    else 'https://api-m.paypal.com'
+)
+# Feature flag: when True, the donation flow uses Advanced Checkout
+# (inline card fields + Smart Buttons). When False, legacy Payments
+# Standard + IPN is used. Defaults off until PR 3 lands and is verified.
+PAYPAL_ADVANCED_CHECKOUT = read_boolean(os.getenv('PAYPAL_ADVANCED_CHECKOUT', 'False'))

--- a/team_fundraising/email_utils.py
+++ b/team_fundraising/email_utils.py
@@ -6,6 +6,8 @@ from botocore.exceptions import ClientError
 import logging
 from django.conf import settings
 
+from .text import Donation_text
+
 logger = logging.getLogger(__name__)
 
 
@@ -71,3 +73,49 @@ def send_email(subject, text_content, from_email, to_emails, html_content=None):
             f"{type(e).__name__}: {str(e)}"
         )
         return False
+
+
+def send_donation_emails(donation):
+    """Send the donor thank-you and the fundraiser-notification emails.
+
+    Extracted from paypal.py::process_paypal so the Advanced Checkout
+    capture view and webhook can reuse it. Safe to call more than once,
+    but callers should guard with an idempotent status transition to
+    avoid duplicate sends.
+    """
+    amount_str = '${:,.2f}'.format(donation.amount)
+
+    thank_you_text = (
+        Donation_text.confirmation_email_opening
+        + amount_str + ' to '
+        + donation.fundraiser.name
+        + Donation_text.confirmation_email_closing_text
+    )
+    thank_you_html = (
+        Donation_text.confirmation_email_opening
+        + amount_str + ' to '
+        + donation.fundraiser.name
+        + Donation_text.confirmation_email_closing_html
+    )
+    send_email(
+        Donation_text.confirmation_email_subject,
+        thank_you_text,
+        settings.DEFAULT_FROM_EMAIL,
+        [donation.email],
+        html_content=thank_you_html,
+    )
+
+    if donation.fundraiser and donation.fundraiser.user:
+        notification_text = (
+            Donation_text.notification_email_opening
+            + amount_str + ' from '
+            + donation.name + " <" + donation.email + ">"
+            + ' with the message:\n\n"' + donation.message + '"'
+            + Donation_text.notification_email_closing
+        )
+        send_email(
+            Donation_text.notification_email_subject,
+            notification_text,
+            settings.DEFAULT_FROM_EMAIL,
+            [donation.fundraiser.user.email],
+        )

--- a/team_fundraising/paypal.py
+++ b/team_fundraising/paypal.py
@@ -2,8 +2,7 @@ from paypal.standard.models import ST_PP_COMPLETED
 from django.shortcuts import get_object_or_404
 from django.conf import settings
 from .models import Donation
-from .text import Donation_text
-from .email_utils import send_email
+from .email_utils import send_donation_emails
 
 
 def process_paypal(sender, **kwargs):
@@ -33,43 +32,11 @@ def process_paypal(sender, **kwargs):
 
         donation = get_object_or_404(Donation, pk=ipn_obj.custom)
 
-        # TODO: write these to the db or a file so we have some traceability
-        # print(f"{ipn_obj.mc_gross}  {ipn_obj.mc_currency}")
-
         donation.payment_method = 'paypal'
         donation.payment_status = 'paid'
         donation.save()
 
-        thank_you_email_text = (Donation_text.confirmation_email_opening
-                                + '${:,.2f}'.format(donation.amount) + ' to '
-                                + donation.fundraiser.name
-                                + Donation_text.confirmation_email_closing_text)
-
-        thank_you_email_html = (Donation_text.confirmation_email_opening
-                                + '${:,.2f}'.format(donation.amount) + ' to '
-                                + donation.fundraiser.name
-                                + Donation_text.confirmation_email_closing_html)
-
-        # send the thank you email
-        send_email(
-            Donation_text.confirmation_email_subject,
-            thank_you_email_text,
-            settings.DEFAULT_FROM_EMAIL,
-            [donation.email],
-            html_content=thank_you_email_html
-        )
-
-        # send the notification email to the fundraiser
-        send_email(
-            Donation_text.notification_email_subject,
-            Donation_text.notification_email_opening
-            + '${:,.2f}'.format(donation.amount) + ' from '
-            + donation.name + " <" + donation.email + ">"
-            + ' with the message:\n\n"' + donation.message + '"'
-            + Donation_text.notification_email_closing,
-            settings.DEFAULT_FROM_EMAIL,
-            [donation.fundraiser.user.email]
-        )
+        send_donation_emails(donation)
 
     else:
         print('not completed')

--- a/team_fundraising/paypal_api.py
+++ b/team_fundraising/paypal_api.py
@@ -1,0 +1,181 @@
+"""REST client for the PayPal Orders v2 API (Advanced Checkout).
+
+Wraps the minimum surface we need: OAuth token fetch, order create/capture,
+and webhook signature verification. We intentionally use ``requests`` plus
+Django's cache instead of pulling in paypalserversdk — the surface is small
+enough that the SDK would be more overhead than help.
+
+All callable entry points raise :class:`PayPalAPIError` on failure so callers
+can surface a single exception type to the user.
+"""
+
+import json
+import logging
+
+import requests
+from django.conf import settings
+from django.core.cache import cache
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_CACHE_KEY = 'paypal:access_token'
+# Subtract from PayPal's reported TTL so we never hand out a token that
+# expires mid-request.
+_TOKEN_SAFETY_MARGIN_SECONDS = 60
+_HTTP_TIMEOUT_SECONDS = 30
+
+
+class PayPalAPIError(Exception):
+    """Raised when PayPal's REST API returns an error or unexpected response."""
+
+
+def _api_base() -> str:
+    """Return the PayPal REST API base URL for the configured environment."""
+    return settings.PAYPAL_API_BASE.rstrip('/')
+
+
+def _require_credentials() -> None:
+    """Fail fast with a clear message if REST credentials are missing."""
+    if not settings.PAYPAL_CLIENT_ID or not settings.PAYPAL_CLIENT_SECRET:
+        raise PayPalAPIError(
+            'PayPal REST credentials not configured. '
+            'Set PAYPAL_CLIENT_ID and PAYPAL_CLIENT_SECRET in your environment.'
+        )
+
+
+def get_access_token() -> str:
+    """Return a cached OAuth2 access token, fetching a fresh one if needed."""
+    cached = cache.get(_TOKEN_CACHE_KEY)
+    if cached:
+        return cached
+
+    _require_credentials()
+
+    response = requests.post(
+        f'{_api_base()}/v1/oauth2/token',
+        data={'grant_type': 'client_credentials'},
+        auth=(settings.PAYPAL_CLIENT_ID, settings.PAYPAL_CLIENT_SECRET),
+        headers={'Accept': 'application/json'},
+        timeout=_HTTP_TIMEOUT_SECONDS,
+    )
+    if response.status_code != 200:
+        logger.error(
+            'PayPal token fetch failed: %s %s',
+            response.status_code, response.text,
+        )
+        raise PayPalAPIError(
+            f'Failed to obtain PayPal access token ({response.status_code})'
+        )
+
+    payload = response.json()
+    token = payload['access_token']
+    ttl = int(payload.get('expires_in', 32000)) - _TOKEN_SAFETY_MARGIN_SECONDS
+    cache.set(_TOKEN_CACHE_KEY, token, timeout=max(ttl, 60))
+    return token
+
+
+def _auth_headers() -> dict:
+    return {
+        'Authorization': f'Bearer {get_access_token()}',
+        'Content-Type': 'application/json',
+    }
+
+
+def create_order(donation) -> dict:
+    """Create a PayPal order for ``donation`` and return the order payload.
+
+    ``custom_id`` is set to the Donation primary key so capture responses and
+    webhook events can be correlated back to the row.
+    """
+    payload = {
+        'intent': 'CAPTURE',
+        'purchase_units': [{
+            'reference_id': str(donation.id),
+            'custom_id': str(donation.id),
+            'invoice_id': f'TRIPLE_CROWN_{donation.id}',
+            'description': 'Donation',
+            'amount': {
+                'currency_code': 'CAD',
+                'value': f'{donation.amount:.2f}',
+            },
+        }],
+    }
+    response = requests.post(
+        f'{_api_base()}/v2/checkout/orders',
+        json=payload,
+        headers=_auth_headers(),
+        timeout=_HTTP_TIMEOUT_SECONDS,
+    )
+    if response.status_code not in (200, 201):
+        logger.error(
+            'PayPal create_order failed (donation=%s): %s %s',
+            donation.id, response.status_code, response.text,
+        )
+        raise PayPalAPIError(
+            f'Failed to create PayPal order ({response.status_code})'
+        )
+    return response.json()
+
+
+def capture_order(order_id: str) -> dict:
+    """Capture a previously-created PayPal order and return the payload."""
+    response = requests.post(
+        f'{_api_base()}/v2/checkout/orders/{order_id}/capture',
+        json={},
+        headers=_auth_headers(),
+        timeout=_HTTP_TIMEOUT_SECONDS,
+    )
+    if response.status_code not in (200, 201):
+        logger.error(
+            'PayPal capture_order failed (order=%s): %s %s',
+            order_id, response.status_code, response.text,
+        )
+        raise PayPalAPIError(
+            f'Failed to capture PayPal order ({response.status_code})'
+        )
+    return response.json()
+
+
+def verify_webhook(headers, body: bytes) -> bool:
+    """Verify a webhook event's signature by asking PayPal to validate it.
+
+    Arguments:
+        headers: case-insensitive mapping (e.g. ``request.headers``).
+        body: raw request body bytes as received from PayPal.
+
+    Returns True only when PayPal responds with ``verification_status=SUCCESS``.
+    """
+    if not settings.PAYPAL_WEBHOOK_ID:
+        logger.error('PAYPAL_WEBHOOK_ID is not configured; refusing to verify.')
+        return False
+
+    try:
+        event = json.loads(body)
+    except (TypeError, ValueError) as exc:
+        logger.error('PayPal webhook body could not be parsed: %s', exc)
+        return False
+
+    payload = {
+        'auth_algo': headers.get('paypal-auth-algo'),
+        'cert_url': headers.get('paypal-cert-url'),
+        'transmission_id': headers.get('paypal-transmission-id'),
+        'transmission_sig': headers.get('paypal-transmission-sig'),
+        'transmission_time': headers.get('paypal-transmission-time'),
+        'webhook_id': settings.PAYPAL_WEBHOOK_ID,
+        'webhook_event': event,
+    }
+
+    response = requests.post(
+        f'{_api_base()}/v1/notifications/verify-webhook-signature',
+        json=payload,
+        headers=_auth_headers(),
+        timeout=_HTTP_TIMEOUT_SECONDS,
+    )
+    if response.status_code != 200:
+        logger.error(
+            'PayPal verify_webhook failed: %s %s',
+            response.status_code, response.text,
+        )
+        return False
+
+    return response.json().get('verification_status') == 'SUCCESS'

--- a/team_fundraising/paypal_api.py
+++ b/team_fundraising/paypal_api.py
@@ -144,6 +144,8 @@ def verify_webhook(headers, body: bytes) -> bool:
         body: raw request body bytes as received from PayPal.
 
     Returns True only when PayPal responds with ``verification_status=SUCCESS``.
+    Any error (bad credentials, network failure, malformed body, unset
+    webhook id) returns False so callers can respond with a plain 400.
     """
     if not settings.PAYPAL_WEBHOOK_ID:
         logger.error('PAYPAL_WEBHOOK_ID is not configured; refusing to verify.')
@@ -165,12 +167,23 @@ def verify_webhook(headers, body: bytes) -> bool:
         'webhook_event': event,
     }
 
-    response = requests.post(
-        f'{_api_base()}/v1/notifications/verify-webhook-signature',
-        json=payload,
-        headers=_auth_headers(),
-        timeout=_HTTP_TIMEOUT_SECONDS,
-    )
+    try:
+        auth_headers = _auth_headers()
+    except PayPalAPIError as exc:
+        logger.error('PayPal webhook verify could not obtain token: %s', exc)
+        return False
+
+    try:
+        response = requests.post(
+            f'{_api_base()}/v1/notifications/verify-webhook-signature',
+            json=payload,
+            headers=auth_headers,
+            timeout=_HTTP_TIMEOUT_SECONDS,
+        )
+    except requests.RequestException as exc:
+        logger.error('PayPal verify_webhook network error: %s', exc)
+        return False
+
     if response.status_code != 200:
         logger.error(
             'PayPal verify_webhook failed: %s %s',
@@ -178,4 +191,15 @@ def verify_webhook(headers, body: bytes) -> bool:
         )
         return False
 
-    return response.json().get('verification_status') == 'SUCCESS'
+    result = response.json()
+    if result.get('verification_status') != 'SUCCESS':
+        # PayPal accepted the request but said the signature doesn't match.
+        # Usually means PAYPAL_WEBHOOK_ID doesn't match the webhook that
+        # sent this event, or the event was sent from a different env.
+        logger.error(
+            'PayPal verify_webhook returned FAILURE (webhook_id=%s): %s',
+            settings.PAYPAL_WEBHOOK_ID, result,
+        )
+        return False
+
+    return True

--- a/team_fundraising/templates/team_fundraising/donation_advanced.html
+++ b/team_fundraising/templates/team_fundraising/donation_advanced.html
@@ -1,0 +1,255 @@
+{% extends "base.html" %}
+{% load crispy_forms_tags %}
+{% block head %}
+<title>Donate to {{ fundraiser.name }}</title>
+<style>
+  /* Container only needs height — PayPal's iframe brings its own
+     border and input styling. Adding our own border produced a
+     visible double-field effect. */
+  .paypal-card-field {
+    min-height: 45px;
+    margin-bottom: 12px;
+  }
+  #advanced-checkout-error {
+    display: none;
+    margin-top: 12px;
+  }
+  .donation-section {
+    margin-bottom: 1.5rem;
+  }
+  .donation-section .card-header {
+    background-color: #f8f9fa;
+    font-weight: 600;
+    font-size: 1.1rem;
+  }
+</style>
+{% endblock head %}
+{% block content %}
+<br/>
+<h3>Donate to {{ fundraiser.name }}'s fundraising</h3>
+<br/>
+
+<form id="donation-form" onsubmit="return false;">
+    {% csrf_token %}
+
+    <div id="form-errors"></div>
+
+    <div class="card donation-section">
+        <div class="card-header">1. Donation Amount</div>
+        <div class="card-body">
+            <div id="div_id_amount" class="form-group mb-0">
+                <div><input type="radio" class="radio" name="amount" value="10"> <label>$10</label></div>
+                <div><input type="radio" class="radio" name="amount" value="25"> <label>$25</label></div>
+                <div><input type="radio" class="radio" name="amount" value="50"> <label>$50</label></div>
+                <div><input type="radio" class="radio" name="amount" value="100"> <label>$100</label></div>
+                <div>
+                    <input type="radio" class="radio" id="amount-other" name="amount" value="other">
+                    <label for="amount-other" class="col-form-label">Other:</label>
+                    <div class="input-group">
+                        <div class="input-group-prepend">
+                          <span class="input-group-text">$</span>
+                        </div>
+                        <input type="number" min="0" step="0.01" class="form-control"
+                               name="other_amount" size="10"
+                               onclick="document.getElementById('amount-other').checked = true;">
+                    </div>
+                </div>
+                <div class="mt-2">
+                    Donations are allocated to our
+                    <a href="https://triplecrownforheart.ca/the-cause">charities</a>
+                    where funds are of immediate priority.
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card donation-section">
+        <div class="card-header">2. Your Information</div>
+        <div class="card-body">
+            <div>{{ form.name|as_crispy_field }}</div>
+            <div class="form-group">
+                <div id="div_id_anonymous" class="form-check">
+                    <label for="id_anonymous" class="form-check-label">
+                        <input type="checkbox" name="anonymous" class="checkboxinput form-check-input" id="id_anonymous">
+                        Anonymous (your name will not appear on the site)
+                    </label>
+                </div>
+            </div>
+            <div>{{ form.email|as_crispy_field }}</div>
+            <div id="div_id_message" class="form-group mb-0">
+                <label for="id_message" class="col-form-label">
+                    Message (This will appear along with your donation)
+                </label>
+                <textarea name="message" cols="40" rows="3"
+                          class="textarea form-control" id="id_message"></textarea>
+            </div>
+        </div>
+    </div>
+
+    <div class="card donation-section">
+        <div class="card-header">3. Payment</div>
+        <div class="card-body">
+            <div id="card-fields-container">
+                <label>Cardholder name</label>
+                <div id="card-name-field-container" class="paypal-card-field"></div>
+                <label>Card number</label>
+                <div id="card-number-field-container" class="paypal-card-field"></div>
+                <div class="row">
+                    <div class="col">
+                        <label>Expiry (MM/YY)</label>
+                        <div id="card-expiry-field-container" class="paypal-card-field"></div>
+                    </div>
+                    <div class="col">
+                        <label>CVV</label>
+                        <div id="card-cvv-field-container" class="paypal-card-field"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card donation-section">
+        <div class="card-header">4. Tax Receipt (Optional)</div>
+        <div class="card-body">
+            <div class="mb-3">
+                Fill in the following to receive a tax receipt for donations over $20:
+            </div>
+            <div>{{ form.tax_name|as_crispy_field }}</div>
+            <div>{{ form.address|as_crispy_field }}</div>
+            <div>{{ form.city|as_crispy_field }}</div>
+            <div>{{ form.province|as_crispy_field }}</div>
+            <div>{{ form.country|as_crispy_field }}</div>
+            <div>{{ form.postal_code|as_crispy_field }}</div>
+        </div>
+    </div>
+</form>
+
+<button type="button" id="card-submit-button" class="btn btn-primary btn-lg btn-block">
+    Donate with card
+</button>
+
+<div id="advanced-checkout-error" class="alert alert-danger"></div>
+
+<script src="https://www.paypal.com/sdk/js?client-id={{ paypal_client_id }}&currency=CAD&components=card-fields&intent=capture"></script>
+<script>
+(function () {
+  const CREATE_ORDER_URL = "{% url 'team_fundraising:create_order' fundraiser.id %}";
+  const FUNDRAISER_URL = "{% url 'team_fundraising:fundraiser' fundraiser.id %}";
+
+  let currentDonationID = null;
+
+  function csrfToken() {
+    const match = document.cookie.match(/csrftoken=([^;]+)/);
+    return match ? match[1] : '';
+  }
+
+  function showError(msg) {
+    const el = document.getElementById('advanced-checkout-error');
+    el.textContent = msg;
+    el.style.display = 'block';
+  }
+
+  function clearError() {
+    const el = document.getElementById('advanced-checkout-error');
+    el.textContent = '';
+    el.style.display = 'none';
+  }
+
+  function validateClientSide() {
+    const form = document.getElementById('donation-form');
+    const fd = new FormData(form);
+    const amount = fd.get('amount');
+    const otherAmount = fd.get('other_amount');
+    if (!amount || (amount === 'other' && !otherAmount)) {
+      return 'Please choose or enter a donation amount.';
+    }
+    if (!fd.get('name')) return 'Please enter your name.';
+    if (!fd.get('email')) return 'Please enter your email.';
+    return null;
+  }
+
+  async function createOrder() {
+    clearError();
+    const validationError = validateClientSide();
+    if (validationError) {
+      showError(validationError);
+      throw new Error(validationError);
+    }
+
+    const form = document.getElementById('donation-form');
+    const fd = new FormData(form);
+
+    const response = await fetch(CREATE_ORDER_URL, {
+      method: 'POST',
+      headers: { 'X-CSRFToken': csrfToken() },
+      body: fd,
+    });
+    const result = await response.json();
+
+    if (!response.ok) {
+      const msg = result.error || 'Could not start payment.';
+      showError(msg);
+      throw new Error(msg);
+    }
+
+    currentDonationID = result.donationID;
+    return result.orderID;
+  }
+
+  async function onApprove(data) {
+    const captureUrl = '/team_fundraising/donation/'
+      + currentDonationID + '/capture/';
+    const response = await fetch(captureUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': csrfToken(),
+      },
+      body: JSON.stringify({ orderID: data.orderID }),
+    });
+    const result = await response.json();
+
+    if (!response.ok) {
+      showError(result.error || 'Payment could not be completed.');
+      return;
+    }
+
+    window.location.href = FUNDRAISER_URL;
+  }
+
+  function onError(err) {
+    console.error('PayPal error:', err);
+    showError('An error occurred during payment. Please try again.');
+  }
+
+  const cardFields = paypal.CardFields({
+    createOrder: createOrder,
+    onApprove: onApprove,
+    onError: onError,
+  });
+
+  if (cardFields.isEligible()) {
+    cardFields.NameField().render('#card-name-field-container');
+    cardFields.NumberField().render('#card-number-field-container');
+    cardFields.ExpiryField().render('#card-expiry-field-container');
+    cardFields.CVVField().render('#card-cvv-field-container');
+
+    document.getElementById('card-submit-button').addEventListener(
+      'click',
+      () => {
+        clearError();
+        const err = validateClientSide();
+        if (err) { showError(err); return; }
+        cardFields.submit().catch((e) => {
+          console.error('Card submit error:', e);
+          showError('Card could not be processed. Please check the details.');
+        });
+      },
+    );
+  } else {
+    document.getElementById('card-fields-container').style.display = 'none';
+    document.getElementById('card-submit-button').style.display = 'none';
+  }
+})();
+</script>
+{% endblock content %}

--- a/team_fundraising/tests/test_paypal_api.py
+++ b/team_fundraising/tests/test_paypal_api.py
@@ -154,3 +154,15 @@ class TestPayPalAPI(TestCase):
     def test_verify_webhook_rejects_unparseable_body(self, mock_post):
         self.assertFalse(paypal_api.verify_webhook({}, b'not-json'))
         mock_post.assert_not_called()
+
+    @patch('team_fundraising.paypal_api.requests.post')
+    def test_verify_webhook_returns_false_when_token_fetch_fails(
+        self, mock_post,
+    ):
+        # Token endpoint returns 401 — verify_webhook must return False
+        # rather than propagating PayPalAPIError (which would 500 the view).
+        mock_post.return_value = self._mock_response(
+            401, {'error': 'invalid_client'}
+        )
+        body = json.dumps({'event_type': 'PAYMENT.CAPTURE.COMPLETED'}).encode()
+        self.assertFalse(paypal_api.verify_webhook({}, body))

--- a/team_fundraising/tests/test_paypal_api.py
+++ b/team_fundraising/tests/test_paypal_api.py
@@ -1,0 +1,156 @@
+"""Unit tests for the PayPal REST client (team_fundraising/paypal_api.py).
+
+HTTP calls are mocked; these tests check request shape and response handling
+only. They do not exercise the real PayPal sandbox.
+"""
+import json
+from unittest.mock import patch, MagicMock
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from .. import paypal_api
+from ..models import Campaign, Fundraiser, Donation
+
+
+@override_settings(
+    PAYPAL_CLIENT_ID='test-client-id',
+    PAYPAL_CLIENT_SECRET='test-secret',
+    PAYPAL_API_BASE='https://api-m.sandbox.paypal.com',
+    PAYPAL_WEBHOOK_ID='WH-TEST',
+)
+class TestPayPalAPI(TestCase):
+    """Exercises paypal_api.py with mocked HTTP."""
+
+    @classmethod
+    def setUpTestData(cls):
+        campaign = Campaign.objects.create(
+            name='Test Campaign',
+            goal=1000,
+            campaign_message='Test',
+            default_fundraiser_message='Default',
+            default_fundraiser_amount=100,
+        )
+        fundraiser = Fundraiser.objects.create(
+            campaign=campaign, name='Test Fundraiser', goal=500,
+        )
+        cls.donation = Donation.objects.create(
+            fundraiser=fundraiser,
+            name='Jane Donor',
+            email='jane@example.com',
+            amount=42.50,
+            payment_method='paypal',
+            payment_status='pending',
+        )
+
+    def setUp(self):
+        cache.clear()
+
+    def _mock_response(self, status_code=200, json_body=None):
+        response = MagicMock()
+        response.status_code = status_code
+        response.json.return_value = json_body or {}
+        response.text = json.dumps(json_body or {})
+        return response
+
+    @override_settings(CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        }
+    })
+    @patch('team_fundraising.paypal_api.requests.post')
+    def test_get_access_token_fetches_and_caches(self, mock_post):
+        # Use a real cache for this test; dev.py swaps in DummyCache during
+        # test runs, which would defeat the caching assertion below.
+        cache.clear()
+        mock_post.return_value = self._mock_response(
+            200, {'access_token': 'abc123', 'expires_in': 3600}
+        )
+
+        token = paypal_api.get_access_token()
+        self.assertEqual(token, 'abc123')
+        self.assertEqual(mock_post.call_count, 1)
+
+        # Second call should hit the cache, not the API.
+        token_again = paypal_api.get_access_token()
+        self.assertEqual(token_again, 'abc123')
+        self.assertEqual(mock_post.call_count, 1)
+
+    @override_settings(PAYPAL_CLIENT_ID='', PAYPAL_CLIENT_SECRET='')
+    def test_get_access_token_raises_without_credentials(self):
+        with self.assertRaises(paypal_api.PayPalAPIError):
+            paypal_api.get_access_token()
+
+    @patch('team_fundraising.paypal_api.requests.post')
+    def test_get_access_token_raises_on_http_error(self, mock_post):
+        mock_post.return_value = self._mock_response(401, {'error': 'bad'})
+        with self.assertRaises(paypal_api.PayPalAPIError):
+            paypal_api.get_access_token()
+
+    @patch('team_fundraising.paypal_api.requests.post')
+    def test_create_order_sends_expected_payload(self, mock_post):
+        # First call is token fetch, second is the order.
+        mock_post.side_effect = [
+            self._mock_response(200, {'access_token': 't', 'expires_in': 3600}),
+            self._mock_response(201, {'id': 'ORDER-1', 'status': 'CREATED'}),
+        ]
+
+        result = paypal_api.create_order(self.donation)
+
+        self.assertEqual(result['id'], 'ORDER-1')
+        order_call = mock_post.call_args_list[1]
+        self.assertIn('/v2/checkout/orders', order_call.args[0])
+        sent = order_call.kwargs['json']
+        self.assertEqual(sent['intent'], 'CAPTURE')
+        self.assertEqual(sent['purchase_units'][0]['custom_id'], str(self.donation.id))
+        self.assertEqual(sent['purchase_units'][0]['amount']['currency_code'], 'CAD')
+        self.assertEqual(sent['purchase_units'][0]['amount']['value'], '42.50')
+
+    @patch('team_fundraising.paypal_api.requests.post')
+    def test_capture_order_hits_capture_endpoint(self, mock_post):
+        mock_post.side_effect = [
+            self._mock_response(200, {'access_token': 't', 'expires_in': 3600}),
+            self._mock_response(201, {'id': 'ORDER-1', 'status': 'COMPLETED'}),
+        ]
+
+        result = paypal_api.capture_order('ORDER-1')
+
+        self.assertEqual(result['status'], 'COMPLETED')
+        capture_call = mock_post.call_args_list[1]
+        self.assertIn('/v2/checkout/orders/ORDER-1/capture', capture_call.args[0])
+
+    @patch('team_fundraising.paypal_api.requests.post')
+    def test_verify_webhook_returns_true_on_success(self, mock_post):
+        mock_post.side_effect = [
+            self._mock_response(200, {'access_token': 't', 'expires_in': 3600}),
+            self._mock_response(200, {'verification_status': 'SUCCESS'}),
+        ]
+
+        headers = {
+            'paypal-auth-algo': 'SHA256withRSA',
+            'paypal-cert-url': 'https://example/cert',
+            'paypal-transmission-id': 'tid',
+            'paypal-transmission-sig': 'sig',
+            'paypal-transmission-time': '2026-01-01T00:00:00Z',
+        }
+        body = json.dumps({'event_type': 'PAYMENT.CAPTURE.COMPLETED'}).encode()
+
+        self.assertTrue(paypal_api.verify_webhook(headers, body))
+
+    @patch('team_fundraising.paypal_api.requests.post')
+    def test_verify_webhook_returns_false_on_failure(self, mock_post):
+        mock_post.side_effect = [
+            self._mock_response(200, {'access_token': 't', 'expires_in': 3600}),
+            self._mock_response(200, {'verification_status': 'FAILURE'}),
+        ]
+        body = json.dumps({'event_type': 'PAYMENT.CAPTURE.COMPLETED'}).encode()
+        self.assertFalse(paypal_api.verify_webhook({}, body))
+
+    def test_verify_webhook_rejects_when_webhook_id_unset(self):
+        with override_settings(PAYPAL_WEBHOOK_ID=''):
+            self.assertFalse(paypal_api.verify_webhook({}, b'{}'))
+
+    @patch('team_fundraising.paypal_api.requests.post')
+    def test_verify_webhook_rejects_unparseable_body(self, mock_post):
+        self.assertFalse(paypal_api.verify_webhook({}, b'not-json'))
+        mock_post.assert_not_called()

--- a/team_fundraising/tests/test_paypal_views.py
+++ b/team_fundraising/tests/test_paypal_views.py
@@ -300,3 +300,29 @@ class TestPayPalWebhook(PayPalViewsTestBase):
         )
 
         self.assertEqual(response.status_code, 404)
+
+
+@override_settings(PAYPAL_CLIENT_ID='test-client-id')
+class TestDonationTemplateFeatureFlag(PayPalViewsTestBase):
+    """Ensures the feature flag picks the right template."""
+
+    @override_settings(PAYPAL_ADVANCED_CHECKOUT=False)
+    def test_legacy_template_when_flag_off(self):
+        response = self.client.get(
+            reverse('team_fundraising:donation', args=[self.fundraiser.id]),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'team_fundraising/donation.html')
+
+    @override_settings(PAYPAL_ADVANCED_CHECKOUT=True)
+    def test_advanced_template_when_flag_on(self):
+        response = self.client.get(
+            reverse('team_fundraising:donation', args=[self.fundraiser.id]),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(
+            response, 'team_fundraising/donation_advanced.html',
+        )
+        # Sanity: client id and SDK script are in the rendered page.
+        self.assertContains(response, 'paypal.com/sdk/js')
+        self.assertContains(response, 'test-client-id')

--- a/team_fundraising/tests/test_paypal_views.py
+++ b/team_fundraising/tests/test_paypal_views.py
@@ -1,0 +1,302 @@
+"""Tests for the Advanced Checkout views (create/capture/webhook).
+
+PayPal HTTP calls and email sends are mocked; we're testing view behavior,
+state transitions, and idempotency — not the real PayPal sandbox.
+"""
+import json
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from ..models import Campaign, Donation, Fundraiser
+
+
+@override_settings(
+    PAYPAL_CLIENT_ID='test-client-id',
+    PAYPAL_CLIENT_SECRET='test-secret',
+    PAYPAL_API_BASE='https://api-m.sandbox.paypal.com',
+    PAYPAL_WEBHOOK_ID='WH-TEST',
+)
+class PayPalViewsTestBase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.campaign = Campaign.objects.create(
+            name='Test Campaign',
+            goal=1000,
+            campaign_message='Test',
+            default_fundraiser_message='Default',
+            default_fundraiser_amount=100,
+        )
+        cls.fundraiser = Fundraiser.objects.create(
+            campaign=cls.campaign, name='Test Fundraiser', goal=500,
+        )
+
+
+class TestCreateDonationOrder(PayPalViewsTestBase):
+
+    def _valid_form_data(self, amount='50.00'):
+        return {
+            'name': 'Jane Donor',
+            'email': 'jane@example.com',
+            'amount': amount,
+            'anonymous': False,
+            'message': 'Go!',
+            'tax_name': '',
+            'address': '',
+            'city': '',
+            'province': '',
+            'country': '',
+            'postal_code': '',
+        }
+
+    @patch('team_fundraising.views.paypal_api.create_order')
+    def test_creates_pending_donation_and_returns_order_id(self, mock_create):
+        mock_create.return_value = {'id': 'ORDER-ABC', 'status': 'CREATED'}
+
+        response = self.client.post(
+            reverse(
+                'team_fundraising:create_order',
+                args=[self.fundraiser.id],
+            ),
+            data=self._valid_form_data(),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['orderID'], 'ORDER-ABC')
+
+        donation = Donation.objects.get(pk=body['donationID'])
+        self.assertEqual(donation.payment_status, 'pending')
+        self.assertEqual(donation.amount, 50.0)
+        self.assertEqual(donation.fundraiser, self.fundraiser)
+        mock_create.assert_called_once()
+
+    @patch('team_fundraising.views.paypal_api.create_order')
+    def test_accepts_json_body(self, mock_create):
+        mock_create.return_value = {'id': 'ORDER-JSON'}
+
+        response = self.client.post(
+            reverse(
+                'team_fundraising:create_order',
+                args=[self.fundraiser.id],
+            ),
+            data=json.dumps(self._valid_form_data()),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['orderID'], 'ORDER-JSON')
+
+    @patch('team_fundraising.views.paypal_api.create_order')
+    def test_rejects_invalid_form(self, mock_create):
+        response = self.client.post(
+            reverse(
+                'team_fundraising:create_order',
+                args=[self.fundraiser.id],
+            ),
+            data={'name': 'Jane'},  # missing email, amount
+        )
+        self.assertEqual(response.status_code, 400)
+        mock_create.assert_not_called()
+        self.assertEqual(Donation.objects.count(), 0)
+
+    @patch('team_fundraising.views.paypal_api.create_order')
+    def test_returns_502_on_paypal_error(self, mock_create):
+        from .. import paypal_api
+        mock_create.side_effect = paypal_api.PayPalAPIError('boom')
+
+        response = self.client.post(
+            reverse(
+                'team_fundraising:create_order',
+                args=[self.fundraiser.id],
+            ),
+            data=self._valid_form_data(),
+        )
+
+        self.assertEqual(response.status_code, 502)
+        # Donation row still exists — we keep pending records for debugging.
+        self.assertEqual(Donation.objects.count(), 1)
+
+
+class TestCaptureDonationOrder(PayPalViewsTestBase):
+
+    def setUp(self):
+        self.donation = Donation.objects.create(
+            fundraiser=self.fundraiser,
+            name='Jane', email='jane@example.com',
+            amount=50.0, message='',
+            payment_method='paypal', payment_status='pending',
+        )
+
+    def _capture_payload(self, amount='50.00', currency='CAD', status='COMPLETED'):
+        return {
+            'id': 'ORDER-1',
+            'status': status,
+            'purchase_units': [{
+                'payments': {'captures': [{
+                    'amount': {'value': amount, 'currency_code': currency},
+                }]},
+            }],
+        }
+
+    @patch('team_fundraising.views.send_donation_emails')
+    @patch('team_fundraising.views.paypal_api.capture_order')
+    def test_marks_paid_and_sends_emails(self, mock_capture, mock_emails):
+        mock_capture.return_value = self._capture_payload()
+
+        response = self.client.post(
+            reverse('team_fundraising:capture_order', args=[self.donation.id]),
+            data=json.dumps({'orderID': 'ORDER-1'}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.donation.refresh_from_db()
+        self.assertEqual(self.donation.payment_status, 'paid')
+        mock_emails.assert_called_once()
+
+    @patch('team_fundraising.views.send_donation_emails')
+    @patch('team_fundraising.views.paypal_api.capture_order')
+    def test_second_capture_does_not_resend_emails(self, mock_capture, mock_emails):
+        mock_capture.return_value = self._capture_payload()
+        url = reverse('team_fundraising:capture_order', args=[self.donation.id])
+        body = json.dumps({'orderID': 'ORDER-1'})
+
+        self.client.post(url, data=body, content_type='application/json')
+        self.client.post(url, data=body, content_type='application/json')
+
+        self.assertEqual(mock_emails.call_count, 1)
+
+    @patch('team_fundraising.views.send_donation_emails')
+    @patch('team_fundraising.views.paypal_api.capture_order')
+    def test_rejects_amount_mismatch(self, mock_capture, mock_emails):
+        mock_capture.return_value = self._capture_payload(amount='10.00')
+
+        response = self.client.post(
+            reverse('team_fundraising:capture_order', args=[self.donation.id]),
+            data=json.dumps({'orderID': 'ORDER-1'}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.donation.refresh_from_db()
+        self.assertEqual(self.donation.payment_status, 'pending')
+        mock_emails.assert_not_called()
+
+    @patch('team_fundraising.views.paypal_api.capture_order')
+    def test_rejects_non_completed_status(self, mock_capture):
+        mock_capture.return_value = self._capture_payload(status='PENDING')
+
+        response = self.client.post(
+            reverse('team_fundraising:capture_order', args=[self.donation.id]),
+            data=json.dumps({'orderID': 'ORDER-1'}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_rejects_missing_order_id(self):
+        response = self.client.post(
+            reverse('team_fundraising:capture_order', args=[self.donation.id]),
+            data=json.dumps({}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400)
+
+
+class TestPayPalWebhook(PayPalViewsTestBase):
+
+    def setUp(self):
+        self.donation = Donation.objects.create(
+            fundraiser=self.fundraiser,
+            name='Jane', email='jane@example.com',
+            amount=50.0, message='',
+            payment_method='paypal', payment_status='pending',
+        )
+
+    def _event(self, event_type='PAYMENT.CAPTURE.COMPLETED', custom_id=None):
+        return {
+            'event_type': event_type,
+            'resource': {
+                'custom_id': str(custom_id or self.donation.id),
+                'status': 'COMPLETED',
+            },
+        }
+
+    @patch('team_fundraising.views.send_donation_emails')
+    @patch('team_fundraising.views.paypal_api.verify_webhook')
+    def test_marks_paid_on_verified_completion(self, mock_verify, mock_emails):
+        mock_verify.return_value = True
+        body = json.dumps(self._event()).encode()
+
+        response = self.client.post(
+            reverse('team_fundraising:paypal_webhook'),
+            data=body,
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.donation.refresh_from_db()
+        self.assertEqual(self.donation.payment_status, 'paid')
+        mock_emails.assert_called_once()
+
+    @patch('team_fundraising.views.send_donation_emails')
+    @patch('team_fundraising.views.paypal_api.verify_webhook')
+    def test_already_paid_does_not_resend(self, mock_verify, mock_emails):
+        mock_verify.return_value = True
+        self.donation.payment_status = 'paid'
+        self.donation.save()
+
+        response = self.client.post(
+            reverse('team_fundraising:paypal_webhook'),
+            data=json.dumps(self._event()).encode(),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        mock_emails.assert_not_called()
+
+    @patch('team_fundraising.views.paypal_api.verify_webhook')
+    def test_rejects_bad_signature(self, mock_verify):
+        mock_verify.return_value = False
+
+        response = self.client.post(
+            reverse('team_fundraising:paypal_webhook'),
+            data=json.dumps(self._event()).encode(),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.donation.refresh_from_db()
+        self.assertEqual(self.donation.payment_status, 'pending')
+
+    @patch('team_fundraising.views.send_donation_emails')
+    @patch('team_fundraising.views.paypal_api.verify_webhook')
+    def test_non_completion_event_does_nothing(self, mock_verify, mock_emails):
+        mock_verify.return_value = True
+
+        response = self.client.post(
+            reverse('team_fundraising:paypal_webhook'),
+            data=json.dumps(self._event(
+                event_type='PAYMENT.CAPTURE.REFUNDED',
+            )).encode(),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.donation.refresh_from_db()
+        self.assertEqual(self.donation.payment_status, 'pending')
+        mock_emails.assert_not_called()
+
+    @patch('team_fundraising.views.paypal_api.verify_webhook')
+    def test_unknown_donation_returns_404(self, mock_verify):
+        mock_verify.return_value = True
+
+        response = self.client.post(
+            reverse('team_fundraising:paypal_webhook'),
+            data=json.dumps(self._event(custom_id=99999)).encode(),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 404)

--- a/team_fundraising/urls.py
+++ b/team_fundraising/urls.py
@@ -14,6 +14,17 @@ urlpatterns = [
         name='fundraiser'
     ),
     path('donation/<int:fundraiser_id>/', views.new_donation, name="donation"),
+    path(
+        'donation/<int:fundraiser_id>/create-order/',
+        views.create_donation_order,
+        name="create_order",
+    ),
+    path(
+        'donation/<int:donation_id>/capture/',
+        views.capture_donation_order,
+        name="capture_order",
+    ),
+    path('paypal-webhook/', views.paypal_webhook, name="paypal_webhook"),
     path('paypal_donation/<int:fundraiser_id>/', Paypal_donation.as_view()),
     path(
         'accounts/update_fundraiser/',

--- a/team_fundraising/views.py
+++ b/team_fundraising/views.py
@@ -91,6 +91,20 @@ def new_donation(request, fundraiser_id):
     fundraiser = get_object_or_404(Fundraiser, pk=fundraiser_id)
     campaign = Campaign.objects.filter(fundraiser=fundraiser_id).first()
 
+    # New flow: the Advanced Checkout template drives submission from JS,
+    # so we never receive a POST here when the flag is on.
+    if settings.PAYPAL_ADVANCED_CHECKOUT:
+        return render(
+            request,
+            'team_fundraising/donation_advanced.html',
+            {
+                'form': DonationForm(),
+                'campaign': campaign,
+                'fundraiser': fundraiser,
+                'paypal_client_id': settings.PAYPAL_CLIENT_ID,
+            },
+        )
+
     if request.method == "POST":
 
         form = DonationForm(request.POST)
@@ -325,6 +339,9 @@ def capture_donation_order(request, donation_id):
         return JsonResponse({'error': 'Amount mismatch'}, status=400)
 
     _mark_donation_paid(donation.id)
+
+    # Flash message picked up on the fundraiser page the JS redirects to.
+    messages.add_message(request, messages.SUCCESS, Donation_text.thank_you)
 
     return JsonResponse({'status': 'success', 'donationID': donation.id})
 

--- a/team_fundraising/views.py
+++ b/team_fundraising/views.py
@@ -1,7 +1,13 @@
+import json
+import logging
+
 from django.shortcuts import get_object_or_404, render, redirect
 from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpResponse, JsonResponse
 from django.urls import reverse
 from django.views.decorators.cache import cache_page
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
 from django.contrib import messages
 from django.contrib.auth import authenticate, login, update_session_auth_hash
 from django.contrib.auth.models import User
@@ -10,12 +16,12 @@ from django.contrib.auth.decorators import login_required
 from django.conf import settings
 from django.views import View
 from paypal.standard.forms import PayPalPaymentsForm
-import logging
 
+from . import paypal_api
 from .models import Campaign, Fundraiser, Donation, ProxyUser
 from .forms import DonationForm, UserForm, FundraiserForm, SignUpForm
 from .text import Donation_text, Fundraiser_text
-from .email_utils import send_email
+from .email_utils import send_email, send_donation_emails
 
 logger = logging.getLogger(__name__)
 
@@ -200,6 +206,181 @@ class Paypal_donation(View):
             }
 
         return render(request, self.template_name, context)
+
+
+def _parse_json_body(request):
+    """Return the decoded JSON body or None if it's not valid JSON."""
+    try:
+        return json.loads(request.body)
+    except (TypeError, ValueError):
+        return None
+
+
+@require_POST
+def create_donation_order(request, fundraiser_id):
+    """Create a pending Donation and a PayPal order, return the order id.
+
+    Called by the Advanced Checkout JS before the user confirms payment.
+    Accepts form-encoded or JSON bodies so the frontend can post either.
+    """
+    fundraiser = get_object_or_404(Fundraiser, pk=fundraiser_id)
+
+    if request.content_type == 'application/json':
+        data = _parse_json_body(request)
+        if data is None:
+            return JsonResponse({'error': 'Invalid JSON'}, status=400)
+    else:
+        data = request.POST
+
+    form = DonationForm(data)
+    if not form.is_valid():
+        return JsonResponse(
+            {'error': 'Invalid form', 'fields': form.errors},
+            status=400,
+        )
+
+    donation = Donation.objects.create(
+        fundraiser=fundraiser,
+        name=form.cleaned_data['name'],
+        amount=float(form.cleaned_data['amount']),
+        email=form.cleaned_data['email'],
+        anonymous=form.cleaned_data['anonymous'],
+        message=form.cleaned_data['message'],
+        tax_name=form.cleaned_data['tax_name'],
+        address=form.cleaned_data['address'],
+        city=form.cleaned_data['city'],
+        province=form.cleaned_data['province'],
+        country=form.cleaned_data['country'],
+        postal_code=form.cleaned_data['postal_code'],
+        payment_method='paypal',
+        payment_status='pending',
+    )
+
+    try:
+        order = paypal_api.create_order(donation)
+    except paypal_api.PayPalAPIError:
+        logger.exception('PayPal create_order failed for donation %s', donation.id)
+        return JsonResponse(
+            {'error': 'Could not initiate payment. Please try again.'},
+            status=502,
+        )
+
+    return JsonResponse({'orderID': order['id'], 'donationID': donation.id})
+
+
+@require_POST
+def capture_donation_order(request, donation_id):
+    """Capture a PayPal order, verify its amount, and mark the donation paid.
+
+    Uses an atomic UPDATE to guarantee emails are sent at most once, even
+    if the webhook arrives before or after this call returns.
+    """
+    donation = get_object_or_404(Donation, pk=donation_id)
+
+    data = _parse_json_body(request)
+    if data is None:
+        return JsonResponse({'error': 'Invalid JSON'}, status=400)
+
+    order_id = data.get('orderID')
+    if not order_id:
+        return JsonResponse({'error': 'orderID required'}, status=400)
+
+    try:
+        capture = paypal_api.capture_order(order_id)
+    except paypal_api.PayPalAPIError:
+        logger.exception('PayPal capture_order failed for donation %s', donation.id)
+        return JsonResponse(
+            {'error': 'Could not complete payment.'},
+            status=502,
+        )
+
+    if capture.get('status') != 'COMPLETED':
+        logger.error(
+            'PayPal capture status %s for donation %s',
+            capture.get('status'), donation.id,
+        )
+        return JsonResponse({'error': 'Capture not completed'}, status=400)
+
+    try:
+        captured = (
+            capture['purchase_units'][0]['payments']['captures'][0]['amount']
+        )
+        captured_amount = float(captured['value'])
+        captured_currency = captured['currency_code']
+    except (KeyError, IndexError, TypeError, ValueError):
+        logger.exception(
+            'Unexpected capture payload shape for donation %s', donation.id,
+        )
+        return JsonResponse({'error': 'Invalid capture response'}, status=502)
+
+    # Guard against client-side amount tampering: PayPal's captured amount
+    # is the authoritative figure, compared against what we stored.
+    if (captured_currency != 'CAD'
+            or abs(captured_amount - float(donation.amount)) > 0.01):
+        logger.error(
+            'Capture amount/currency mismatch for donation %s: '
+            '%s %s vs expected %s CAD',
+            donation.id, captured_amount, captured_currency, donation.amount,
+        )
+        return JsonResponse({'error': 'Amount mismatch'}, status=400)
+
+    _mark_donation_paid(donation.id)
+
+    return JsonResponse({'status': 'success', 'donationID': donation.id})
+
+
+@csrf_exempt
+@require_POST
+def paypal_webhook(request):
+    """Idempotent backstop for capture state — runs if the user closed the
+    tab before ``capture_donation_order`` finished, or if PayPal retries.
+
+    Verifies the signature with PayPal before trusting any field in the body.
+    """
+    if not paypal_api.verify_webhook(request.headers, request.body):
+        logger.error('PayPal webhook signature verification failed')
+        return HttpResponse(status=400)
+
+    event = _parse_json_body(request)
+    if event is None:
+        return HttpResponse(status=400)
+
+    if event.get('event_type') != 'PAYMENT.CAPTURE.COMPLETED':
+        # Other event types are acknowledged but not acted on.
+        return HttpResponse(status=200)
+
+    custom_id = (event.get('resource') or {}).get('custom_id')
+    if not custom_id:
+        logger.error('PayPal webhook missing custom_id')
+        return HttpResponse(status=400)
+
+    try:
+        donation_id = int(custom_id)
+    except (TypeError, ValueError):
+        logger.error('PayPal webhook bad custom_id: %s', custom_id)
+        return HttpResponse(status=400)
+
+    if not Donation.objects.filter(pk=donation_id).exists():
+        logger.error('PayPal webhook for unknown donation: %s', donation_id)
+        return HttpResponse(status=404)
+
+    _mark_donation_paid(donation_id)
+    return HttpResponse(status=200)
+
+
+def _mark_donation_paid(donation_id):
+    """Flip a donation from pending to paid and send emails once.
+
+    Uses a conditional UPDATE so concurrent capture+webhook calls can't
+    both trigger email sends.
+    """
+    rows = Donation.objects.filter(
+        pk=donation_id, payment_status='pending',
+    ).update(payment_status='paid')
+
+    if rows:
+        donation = Donation.objects.get(pk=donation_id)
+        send_donation_emails(donation)
 
 
 def signup(request, campaign_id):


### PR DESCRIPTION
Introduces support for PayPal Advanced Checkout (Orders v2 REST API) as an alternative to the IPN PayPal flow. 

It adds all necessary backend and frontend infrastructure for the new integration, including environment configuration, REST API client, and a new donation form with inline card fields. Previous flow is still supported through the `

Shipped behind the `PAYPAL_ADVANCED_CHECKOUT` feature flag — when off, the existing IPN flow is unchanged.

**PayPal Advanced Checkout Integration**

* Added new environment variables in `.env.example` for PayPal REST credentials, webhook ID, and a feature flag to enable Advanced Checkout.
* Updated Django settings in `fundraiser/settings/base.py` to load and expose the new PayPal configuration and feature flag, with logic to select sandbox or live endpoints.
* Implemented a new REST client for PayPal Orders v2 API in `team_fundraising/paypal_api.py`, supporting OAuth token management, order creation, order capture, and webhook verification.

**Frontend: Donation Flow**

* Added a new template `donation_advanced.html` for the Advanced Checkout flow, featuring inline card fields, client-side validation, and PayPal SDK integration.