### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -7,6 +7,9 @@ on:
       - deploy-railway  # TODO: Remove after testing
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     uses: ./.github/workflows/django-tests.yml


### PR DESCRIPTION
Potential fix for [https://github.com/dominikszopa/fundraising-website/security/code-scanning/4](https://github.com/dominikszopa/fundraising-website/security/code-scanning/4)

Add an explicit top-level `permissions` block in `.github/workflows/deploy-railway.yml` so all jobs in this workflow default to least privilege. The best minimal fix here is:

- `contents: read`

This supports `actions/checkout@v4` and avoids granting unnecessary write scopes to `GITHUB_TOKEN`. Place the block at workflow root (after `on:` or before `jobs:`), so it applies consistently to both `test` (reusable workflow call) and `deploy` unless overridden.

No imports, methods, or dependencies are needed—only YAML configuration change in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
