### PR TITLE
Add photo rotation and preview to fundraiser profile editing

### DIFF
--- a/team_fundraising/forms.py
+++ b/team_fundraising/forms.py
@@ -118,6 +118,10 @@ class FundraiserForm(forms.ModelForm):
         widgets = {
             'campaign': forms.HiddenInput(),
             'message': forms.Textarea(attrs={'rows': 3, 'cols': 20}),
+            # Plain file input (not ClearableFileInput) so the redundant
+            # "Currently: ... Clear" line is not shown; the live preview
+            # below the label takes its place.
+            'photo': forms.FileInput(),
         }
 
     def __init__(self, *args, **kwargs):

--- a/team_fundraising/management/commands/generate_small_photos.py
+++ b/team_fundraising/management/commands/generate_small_photos.py
@@ -1,6 +1,3 @@
-import os
-from PIL import Image
-from django.conf import settings
 from django.core.management.base import BaseCommand
 from team_fundraising.models import Fundraiser
 
@@ -21,19 +18,10 @@ class Command(BaseCommand):
 
                 if fundraiser.photo:
 
-                    # Open the original photo
-                    with Image.open(fundraiser.photo.path) as img:
-                        # Create a lower-resolution version
-                        img.thumbnail((800, 800))
-
-                        # Save the lower-resolution version
-                        photo_dir, photo_filename = os.path.split(fundraiser.photo.name)
-                        new_photo_path = os.path.join('photos_small', photo_filename)
-                        img.save(os.path.join(settings.MEDIA_ROOT, new_photo_path))
-
-                        # Update the photo_800 field to point to the new path
-                        fundraiser.photo_small.name = new_photo_path
-                        fundraiser.save()
+                    # Reuse the model's thumbnail logic (EXIF-aware) so this
+                    # command stays in sync with what save() produces.
+                    fundraiser._generate_thumbnail()
+                    fundraiser.save()
 
             except FileNotFoundError:
                 self.stdout.write(

--- a/team_fundraising/models.py
+++ b/team_fundraising/models.py
@@ -11,7 +11,7 @@ from django.contrib.auth.models import User
 from django.db.models import Sum, Count, Max, Q, F, FloatField, Case, When
 from django.db.models.functions import Coalesce
 from django.conf import settings
-from PIL import Image
+from PIL import Image, ImageOps
 
 
 class Campaign(models.Model):
@@ -133,26 +133,85 @@ class Fundraiser(models.Model):
         return self.name
 
     def save(self, *args, **kwargs):
-        # Generate and save the lower-resolution version of the photo.
+        # Persist the record (and any freshly uploaded photo) first, then
+        # regenerate the thumbnail from the now-committed original. Doing this
+        # after super().save() is important: on a new upload the file isn't in
+        # storage yet when save() begins, so generating the thumbnail earlier
+        # would skip it (leaving a stale photo_small on a replaced photo) and
+        # risk consuming the upload stream before it is written.
+        super().save(*args, **kwargs)
+
         # Skip thumbnail regeneration if the original file is missing on disk
         # (can happen for legacy rows whose originals were lost) so we don't
         # 500 the whole save.
         if self.photo and self.photo.storage.exists(self.photo.name):
-            try:
-                with Image.open(self.photo) as img:
-                    img.thumbnail((800, 800))
-                    photo_dir, photo_filename = os.path.split(self.photo.name)
-                    new_photo_path = os.path.join('photos_small', photo_filename)
+            self._generate_thumbnail()
+            super().save(update_fields=['photo_small'])
 
-                    full_dir = os.path.join(settings.MEDIA_ROOT, 'photos_small')
-                    os.makedirs(full_dir, exist_ok=True)
+    def _generate_thumbnail(self):
+        """
+        Create the lower-resolution version of the photo in photos_small/.
 
-                    img.save(os.path.join(settings.MEDIA_ROOT, new_photo_path))
-                    self.photo_small.name = new_photo_path
-            except (FileNotFoundError, OSError):
-                pass
+        Applies the photo's EXIF orientation so images taken on phones (which
+        store the rotation as metadata rather than rotating the pixels) appear
+        upright. Failures are swallowed so a missing or unreadable original
+        does not 500 the surrounding save.
+        """
+        try:
+            with Image.open(self.photo) as img:
+                img = ImageOps.exif_transpose(img)
+                img.thumbnail((800, 800))
+                photo_dir, photo_filename = os.path.split(self.photo.name)
+                new_photo_path = os.path.join('photos_small', photo_filename)
 
-        super().save(*args, **kwargs)
+                full_dir = os.path.join(settings.MEDIA_ROOT, 'photos_small')
+                os.makedirs(full_dir, exist_ok=True)
+
+                img.save(os.path.join(settings.MEDIA_ROOT, new_photo_path))
+                self.photo_small.name = new_photo_path
+        except (FileNotFoundError, OSError):
+            pass
+
+    def rotate_photo(self, degrees):
+        """
+        Rotate the stored original photo clockwise by ``degrees`` (one of
+        90, 180, 270) in place, overwriting the same file so we never
+        accumulate extra versions. Callers should ``save()`` afterwards to
+        regenerate the thumbnail from the rotated original.
+        """
+        if degrees not in (90, 180, 270):
+            return
+
+        if not (self.photo and self.photo.storage.exists(self.photo.name)):
+            return
+
+        path = os.path.join(settings.MEDIA_ROOT, self.photo.name)
+        try:
+            with Image.open(path) as img:
+                # Bake in any EXIF orientation first so the manual rotation is
+                # applied relative to what the user actually sees.
+                img = ImageOps.exif_transpose(img)
+                # PIL rotates counter-clockwise; negate to rotate clockwise.
+                # expand=True keeps the full image for 90/270 turns.
+                rotated = img.rotate(-degrees, expand=True)
+                rotated.save(path)
+        except (FileNotFoundError, OSError):
+            pass
+
+    @property
+    def photo_cache_token(self):
+        """
+        A cache-busting token (the photo file's last-modified time) appended
+        to image URLs so a rotated/replaced photo, which keeps the same
+        filename, is refetched by the browser instead of served stale.
+        """
+        f = self.photo_small or self.photo
+        try:
+            if f:
+                return int(f.storage.get_modified_time(f.name).timestamp())
+        except (FileNotFoundError, OSError, NotImplementedError):
+            pass
+        return 0
 
     def total_raised(self):
         """

--- a/team_fundraising/templates/team_fundraising/fundraiser.html
+++ b/team_fundraising/templates/team_fundraising/fundraiser.html
@@ -28,9 +28,9 @@
         <div class="row">
             <div class="col-lg-6">
                 {% if fundraiser.photo_small %}
-                    <img src="{{ fundraiser.photo_small.url }}" width="200" height="200" class="circle-image">
+                    <img src="{{ fundraiser.photo_small.url }}?v={{ fundraiser.photo_cache_token }}" width="200" height="200" class="circle-image">
                 {% elif fundraiser.photo %}
-                    <img src="{{ fundraiser.photo.url }}" width="200" height="200" class="circle-image">
+                    <img src="{{ fundraiser.photo.url }}?v={{ fundraiser.photo_cache_token }}" width="200" height="200" class="circle-image">
                 {% else %}
                     <img  src="{% static "nophoto.png" %}" alt="Card image cap" width="200" height="200" class="circle-image">
                 {% endif %}

--- a/team_fundraising/templates/team_fundraising/index.html
+++ b/team_fundraising/templates/team_fundraising/index.html
@@ -73,9 +73,9 @@
       {% for fundraiser in fundraisers %}
       <div class="card mt-3 mr-1" style="width: 160px;" data-filter-item data-filter-name="{{ fundraiser.name|lower }}">
         {% if fundraiser.photo_small %}
-        <img class="card-img-top circle-image-small" src="{{ fundraiser.photo_small.url }}" alt="Card image cap" width="140" height="140">
+        <img class="card-img-top circle-image-small" src="{{ fundraiser.photo_small.url }}?v={{ fundraiser.photo_cache_token }}" alt="Card image cap" width="140" height="140">
         {% elif fundraiser.photo %}
-        <img class="card-img-top circle-image-small" src="{{ fundraiser.photo.url }}" alt="Card image cap" width="140" height="140">
+        <img class="card-img-top circle-image-small" src="{{ fundraiser.photo.url }}?v={{ fundraiser.photo_cache_token }}" alt="Card image cap" width="140" height="140">
         {% else %}
         <img class="card-img-top circle-image-small" src="{% static "nophoto.png" %}" alt="Card image cap" width="140" height="140">
         {% endif %}

--- a/team_fundraising/templates/team_fundraising/update_fundraiser.html
+++ b/team_fundraising/templates/team_fundraising/update_fundraiser.html
@@ -102,6 +102,113 @@
             });
         }
     </script>
+
+    {% if campaign.active %}
+    <script>
+        // Add a live preview and rotate controls under the "Photo" heading.
+        // Rotation is previewed instantly with a CSS transform; the chosen
+        // angle is submitted in a hidden field and applied server-side to the
+        // stored photo (overwriting it in place, no extra versions kept).
+        (function () {
+            var photoInput = document.getElementById('id_photo');
+            if (!photoInput) {
+                return;
+            }
+
+            var rotation = 0;
+
+            // Hidden field carrying the requested rotation (0/90/180/270).
+            var rotateField = document.createElement('input');
+            rotateField.type = 'hidden';
+            rotateField.name = 'rotate';
+            rotateField.value = '0';
+
+            // Wrapper for the preview and rotate buttons.
+            var wrapper = document.createElement('div');
+            wrapper.style.marginBottom = '0.75rem';
+
+            // Fixed-size square stage. The image is capped to fit inside it,
+            // so rotating a landscape photo 90 degrees stays within the
+            // reserved space and never overlaps the surrounding fields.
+            var stage = document.createElement('div');
+            stage.style.width = '210px';
+            stage.style.height = '210px';
+            stage.style.display = 'none';
+            stage.style.alignItems = 'center';
+            stage.style.justifyContent = 'center';
+            stage.style.marginBottom = '0.5rem';
+
+            var preview = document.createElement('img');
+            preview.style.maxWidth = '200px';
+            preview.style.maxHeight = '200px';
+            preview.style.transition = 'transform 0.15s ease';
+            {% if fundraiser.photo_small %}
+            preview.src = '{{ fundraiser.photo_small.url }}?v={{ fundraiser.photo_cache_token }}';
+            stage.style.display = 'flex';
+            {% elif fundraiser.photo %}
+            preview.src = '{{ fundraiser.photo.url }}?v={{ fundraiser.photo_cache_token }}';
+            stage.style.display = 'flex';
+            {% endif %}
+            stage.appendChild(preview);
+
+            var leftBtn = document.createElement('button');
+            leftBtn.type = 'button';
+            leftBtn.className = 'btn btn-secondary btn-sm';
+            leftBtn.textContent = '↺ Rotate left';
+
+            var rightBtn = document.createElement('button');
+            rightBtn.type = 'button';
+            rightBtn.className = 'btn btn-secondary btn-sm';
+            rightBtn.style.marginLeft = '0.5rem';
+            rightBtn.textContent = 'Rotate right ↻';
+
+            function applyRotation() {
+                rotation = ((rotation % 360) + 360) % 360;
+                preview.style.transform = 'rotate(' + rotation + 'deg)';
+                rotateField.value = String(rotation);
+            }
+
+            leftBtn.addEventListener('click', function () {
+                rotation -= 90;
+                applyRotation();
+            });
+            rightBtn.addEventListener('click', function () {
+                rotation += 90;
+                applyRotation();
+            });
+
+            // When a new file is chosen, preview it locally and reset rotation.
+            photoInput.addEventListener('change', function () {
+                rotation = 0;
+                applyRotation();
+                var file = photoInput.files && photoInput.files[0];
+                if (file) {
+                    var reader = new FileReader();
+                    reader.onload = function (e) {
+                        preview.src = e.target.result;
+                        stage.style.display = 'flex';
+                    };
+                    reader.readAsDataURL(file);
+                }
+            });
+
+            wrapper.appendChild(stage);
+            wrapper.appendChild(leftBtn);
+            wrapper.appendChild(rightBtn);
+            wrapper.appendChild(rotateField);
+
+            // Insert the controls just after the "Photo" label, above the
+            // file input.
+            var formGroup = photoInput.closest('.form-group');
+            var label = formGroup ? formGroup.querySelector('label') : null;
+            if (label) {
+                label.parentNode.insertBefore(wrapper, label.nextSibling);
+            } else {
+                photoInput.parentNode.insertBefore(wrapper, photoInput);
+            }
+        })();
+    </script>
+    {% endif %}
 </form>
 
 {% endblock content %}

--- a/team_fundraising/tests/test_models.py
+++ b/team_fundraising/tests/test_models.py
@@ -1,5 +1,12 @@
-from django.test import TestCase
+import io
+import os
+import tempfile
+
+from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
 from django.utils import timezone
+from PIL import Image
 from ..models import Campaign, Fundraiser, Donation, Donor
 
 
@@ -114,6 +121,111 @@ class TestFundraiser(TestModels):
         fundraiser = Fundraiser.objects.first()
         total = fundraiser.total_donations()
         self.assertEqual(total, 2)
+
+
+class TestFundraiserPhoto(TestCase):
+    """ Tests for photo thumbnailing and rotation """
+
+    def _make_image_upload(self, width, height, color=(255, 0, 0)):
+        """ Build an in-memory PNG upload of the given dimensions """
+        buffer = io.BytesIO()
+        Image.new('RGB', (width, height), color).save(buffer, format='PNG')
+        buffer.seek(0)
+        return SimpleUploadedFile(
+            'test_photo.png', buffer.read(), content_type='image/png'
+        )
+
+    def setUp(self):
+        self.campaign = Campaign.objects.create(
+            name='Photo Campaign',
+            goal=1000,
+            campaign_message='message',
+            default_fundraiser_message='default message',
+        )
+
+    def test_rotate_photo_swaps_dimensions_in_place(self):
+        """
+        Rotating a non-square photo 90 degrees swaps its width and height
+        and overwrites the same file rather than creating a new one.
+        """
+        with tempfile.TemporaryDirectory() as media_root:
+            with override_settings(MEDIA_ROOT=media_root):
+                fundraiser = Fundraiser.objects.create(
+                    campaign=self.campaign,
+                    name='Photo Fundraiser',
+                    goal=100,
+                    photo=self._make_image_upload(100, 60),
+                )
+
+                original_name = fundraiser.photo.name
+                path = os.path.join(settings.MEDIA_ROOT, original_name)
+
+                with Image.open(path) as img:
+                    self.assertEqual(img.size, (100, 60))
+
+                fundraiser.rotate_photo(90)
+                fundraiser.save()
+
+                # Same filename, no extra version created.
+                self.assertEqual(fundraiser.photo.name, original_name)
+
+                with Image.open(path) as img:
+                    self.assertEqual(img.size, (60, 100))
+
+    def test_thumbnail_generated_on_upload(self):
+        """ Uploading a photo generates a matching photo_small thumbnail """
+        with tempfile.TemporaryDirectory() as media_root:
+            with override_settings(MEDIA_ROOT=media_root):
+                fundraiser = Fundraiser.objects.create(
+                    campaign=self.campaign,
+                    name='Photo Fundraiser',
+                    goal=100,
+                    photo=self._make_image_upload(100, 60),
+                )
+                self.assertTrue(fundraiser.photo_small.name)
+                thumb = os.path.join(settings.MEDIA_ROOT, fundraiser.photo_small.name)
+                with Image.open(thumb) as img:
+                    self.assertEqual(img.size, (100, 60))
+
+    def test_replacing_photo_refreshes_thumbnail(self):
+        """
+        Replacing the photo regenerates photo_small from the new image rather
+        than leaving the previous thumbnail in place.
+        """
+        with tempfile.TemporaryDirectory() as media_root:
+            with override_settings(MEDIA_ROOT=media_root):
+                fundraiser = Fundraiser.objects.create(
+                    campaign=self.campaign,
+                    name='Photo Fundraiser',
+                    goal=100,
+                    photo=self._make_image_upload(100, 60, color=(255, 0, 0)),
+                )
+
+                # Replace with a differently sized, differently coloured image.
+                fundraiser.photo = self._make_image_upload(80, 80, color=(0, 255, 0))
+                fundraiser.save()
+
+                thumb = os.path.join(settings.MEDIA_ROOT, fundraiser.photo_small.name)
+                with Image.open(thumb) as img:
+                    self.assertEqual(img.size, (80, 80))
+                    self.assertEqual(img.convert('RGB').getpixel((0, 0)), (0, 255, 0))
+
+    def test_rotate_photo_ignores_invalid_degrees(self):
+        """ A non-90-multiple rotation is a no-op and leaves the photo intact """
+        with tempfile.TemporaryDirectory() as media_root:
+            with override_settings(MEDIA_ROOT=media_root):
+                fundraiser = Fundraiser.objects.create(
+                    campaign=self.campaign,
+                    name='Photo Fundraiser',
+                    goal=100,
+                    photo=self._make_image_upload(100, 60),
+                )
+                path = os.path.join(settings.MEDIA_ROOT, fundraiser.photo.name)
+
+                fundraiser.rotate_photo(45)
+
+                with Image.open(path) as img:
+                    self.assertEqual(img.size, (100, 60))
 
 
 class TestDonation(TestModels):

--- a/team_fundraising/views.py
+++ b/team_fundraising/views.py
@@ -686,6 +686,18 @@ def update_fundraiser(request, campaign_id=None):
             user_form.save()
             fundraiser_form.save()
 
+            # Apply any rotation the user requested via the preview controls.
+            # The form (and any new upload) is saved first, so rotation always
+            # applies to the current photo and overwrites it in place.
+            try:
+                rotate = int(request.POST.get('rotate', 0))
+            except (TypeError, ValueError):
+                rotate = 0
+
+            if rotate in (90, 180, 270):
+                fundraiser_form.instance.rotate_photo(rotate)
+                fundraiser_form.instance.save()
+
             messages.success(request, 'Your information was updated')
 
             return redirect(
@@ -705,6 +717,7 @@ def update_fundraiser(request, campaign_id=None):
         request, 'team_fundraising/update_fundraiser.html',
         {
             'campaign': fundraiser.campaign,
+            'fundraiser': fundraiser,
             'user_form': user_form,
             'fundraiser_form': fundraiser_form,
             'active_campaign': active_campaign,


### PR DESCRIPTION
Fundraisers can now preview their profile photo and correct its rotation (90° steps) when editing their page.

- **Rotate buttons + live preview** under the Photo heading; rotation is applied server-side to the stored photo in place (no extra versions accumulate).
- **EXIF auto-orientation** on upload so phone photos appear upright.
- **Cache-busting** on photo URLs so a rotated/replaced photo shows immediately.

Also fixes: replacing a photo didn't update the displayed image (thumbnail wasn't regenerated on upload because `save()` checked storage before writing the file). Dropped the redundant "Currently/Clear" file-input line.

Adds 4 model tests; flake8 clean; no new regressions (the suite's pre-existing `test_donations` failures are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)