### PR TITLE
Fix photo rotation when a fundraiser's original photo file is missing

### DIFF
--- a/team_fundraising/models.py
+++ b/team_fundraising/models.py
@@ -174,18 +174,31 @@ class Fundraiser(models.Model):
 
     def rotate_photo(self, degrees):
         """
-        Rotate the stored original photo clockwise by ``degrees`` (one of
-        90, 180, 270) in place, overwriting the same file so we never
-        accumulate extra versions. Callers should ``save()`` afterwards to
-        regenerate the thumbnail from the rotated original.
+        Rotate the stored photo clockwise by ``degrees`` (one of 90, 180, 270)
+        in place, overwriting the same file(s) so we never accumulate extra
+        versions.
+
+        When the original is present we rotate it and let ``save()`` regenerate
+        the thumbnail from it. For legacy rows whose original was lost but whose
+        thumbnail survives, we rotate the thumbnail directly so the displayed
+        image still turns (``save()`` skips thumbnail regeneration when the
+        original is missing). Callers should ``save()`` afterwards.
         """
         if degrees not in (90, 180, 270):
             return
 
-        if not (self.photo and self.photo.storage.exists(self.photo.name)):
-            return
+        if self.photo and self.photo.storage.exists(self.photo.name):
+            # Rotate the original; the thumbnail is rebuilt from it on save().
+            self._rotate_file_in_place(self.photo.name, degrees)
+        elif (self.photo_small
+                and self.photo_small.storage.exists(self.photo_small.name)):
+            # Original is gone, but the thumbnail (what users actually see)
+            # is here, so rotate that.
+            self._rotate_file_in_place(self.photo_small.name, degrees)
 
-        path = os.path.join(settings.MEDIA_ROOT, self.photo.name)
+    def _rotate_file_in_place(self, name, degrees):
+        """ Rotate the media file at ``name`` clockwise by ``degrees`` """
+        path = os.path.join(settings.MEDIA_ROOT, name)
         try:
             with Image.open(path) as img:
                 # Bake in any EXIF orientation first so the manual rotation is
@@ -193,8 +206,7 @@ class Fundraiser(models.Model):
                 img = ImageOps.exif_transpose(img)
                 # PIL rotates counter-clockwise; negate to rotate clockwise.
                 # expand=True keeps the full image for 90/270 turns.
-                rotated = img.rotate(-degrees, expand=True)
-                rotated.save(path)
+                img.rotate(-degrees, expand=True).save(path)
         except (FileNotFoundError, OSError):
             pass
 

--- a/team_fundraising/tests/test_models.py
+++ b/team_fundraising/tests/test_models.py
@@ -210,6 +210,39 @@ class TestFundraiserPhoto(TestCase):
                     self.assertEqual(img.size, (80, 80))
                     self.assertEqual(img.convert('RGB').getpixel((0, 0)), (0, 255, 0))
 
+    def test_rotate_photo_rotates_thumbnail_when_original_missing(self):
+        """
+        Legacy rows can have a thumbnail but a lost original. Rotation should
+        still turn the thumbnail (what users see) rather than silently no-op.
+        """
+        with tempfile.TemporaryDirectory() as media_root:
+            with override_settings(MEDIA_ROOT=media_root):
+                fundraiser = Fundraiser.objects.create(
+                    campaign=self.campaign,
+                    name='Photo Fundraiser',
+                    goal=100,
+                    photo=self._make_image_upload(120, 80),
+                )
+
+                # Simulate the real production scenario: the original file is
+                # gone from disk but the field still references it and the
+                # thumbnail survives.
+                os.remove(os.path.join(settings.MEDIA_ROOT, fundraiser.photo.name))
+
+                self.assertTrue(fundraiser.photo_small.name)
+                self.assertFalse(
+                    fundraiser.photo.storage.exists(fundraiser.photo.name)
+                )
+                thumb = os.path.join(settings.MEDIA_ROOT, fundraiser.photo_small.name)
+                with Image.open(thumb) as img:
+                    self.assertEqual(img.size, (120, 80))
+
+                fundraiser.rotate_photo(90)
+                fundraiser.save()
+
+                with Image.open(thumb) as img:
+                    self.assertEqual(img.size, (80, 120))
+
     def test_rotate_photo_ignores_invalid_degrees(self):
         """ A non-90-multiple rotation is a no-op and leaves the photo intact """
         with tempfile.TemporaryDirectory() as media_root:


### PR DESCRIPTION
Follow-up to #204.

Some production fundraisers have a thumbnail but no original photo file (legacy rows). `rotate_photo` only rotated the original, so it silently did nothing for these — rotation appeared to never work in production (worked locally where originals exist).

**Fix:** rotate the thumbnail directly when the original is missing. Adds a regression test; all model tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)