### PR TITLE
Fix backup workflow: use Postgres 17 client so pg_dump matches the server

### DIFF
--- a/.github/workflows/backup-postgres.yml
+++ b/.github/workflows/backup-postgres.yml
@@ -29,7 +29,7 @@ jobs:
       BACKUP_S3_BUCKET: ${{ secrets.BACKUP_S3_BUCKET }}
       # Must match the Railway Postgres MAJOR version: an older pg_dump refuses
       # to dump a newer server. Confirm with `SELECT version();` and update.
-      PG_MAJOR: '15'
+      PG_MAJOR: '17'
 
     steps:
       - name: Verify required secrets are set
@@ -54,7 +54,11 @@ jobs:
             | sudo tee /etc/apt/sources.list.d/pgdg.list > /dev/null
           sudo apt-get update
           sudo apt-get install -y "postgresql-client-${PG_MAJOR}"
-          pg_dump --version
+          # Call the version-specific binary directly. The runner preinstalls an
+          # older client and Debian's pg_wrapper dispatches /usr/bin/pg_dump to
+          # the HIGHEST installed major, so relying on PATH can pick the wrong
+          # version. The explicit path makes PG_MAJOR authoritative.
+          "/usr/lib/postgresql/${PG_MAJOR}/bin/pg_dump" --version
 
       - name: Dump database and upload to S3
         run: |
@@ -63,7 +67,9 @@ jobs:
           dumpfile="fundraising-${timestamp}.dump"
 
           # Custom format (-Fc): compressed and restorable with pg_restore.
-          pg_dump "$DATABASE_URL" -Fc --no-owner --no-privileges -f "$dumpfile"
+          # Use the version-specific binary (see note in the install step).
+          "/usr/lib/postgresql/${PG_MAJOR}/bin/pg_dump" \
+            "$DATABASE_URL" -Fc --no-owner --no-privileges -f "$dumpfile"
 
           # Guard against a silent/empty dump masquerading as success.
           size="$(stat -c%s "$dumpfile")"


### PR DESCRIPTION
## Summary

Follow-up to #206, which merged before this fix landed. The backup workflow on `main` still has `PG_MAJOR: '15'` and fails against the production database with:

```
pg_dump: error: aborting because of server version mismatch
pg_dump: detail: server version: 17.7; pg_dump version: 16.14
```

## Root cause

The Railway Postgres server is **17.7**, but the job dumped with `pg_dump` **16** — not 15 — because the GitHub runner preinstalls a v16 client and Debian's `pg_wrapper` dispatches `/usr/bin/pg_dump` to the **highest installed major**, ignoring which version we `apt-get install`. So the requested version was never authoritative.

## Fix

- Bump `PG_MAJOR` `15` → `17` to match the server.
- Invoke the version-specific binary directly (`/usr/lib/postgresql/$PG_MAJOR/bin/pg_dump`) in both the version-check and dump steps, so `PG_MAJOR` authoritatively controls the client version regardless of what the runner preinstalls or `pg_wrapper` prefers.

## Testing

- Workflow YAML validated (parses; steps/structure intact).
- After this lands on `main`, re-run *Actions → Backup PostgreSQL to S3 → Run workflow*; the version line should print `pg_dump (PostgreSQL) 17.x`, followed by a successful dump and `Uploaded s3://<bucket>/postgres/...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZvAjfDmcbXvRYph7qARRN

---
_Generated by [Claude Code](https://claude.ai/code/session_013ZvAjfDmcbXvRYph7qARRN)_